### PR TITLE
support apache 2.4 access control syntax

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -19,8 +19,12 @@
 	LogLevel warn
 
 	<Proxy *>
+    <% if node['apache'] && node['apache']['version'] == '2.4' %>
+		Require all granted
+    <% else %>
 		Order Deny,Allow
 		Allow from all
+    <% end %>
 	</Proxy>
 	ProxyPass        / http://localhost:<%= node['stash']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
 	ProxyPassReverse / http://localhost:<%= node['stash']['tomcat']['port'] %>/
@@ -43,8 +47,12 @@
 	LogLevel warn
 
 	<Proxy *>
+    <% if node['apache'] && node['apache']['version'] == '2.4' %>
+		Require all granted
+    <% else %>
 		Order Deny,Allow
 		Allow from all
+    <% end %>
 	</Proxy>
 	ProxyPass        / http://localhost:<%= node['stash']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
 	ProxyPassReverse / http://localhost:<%= node['stash']['tomcat']['port'] %>/


### PR DESCRIPTION
This change allows the stash and apache2 cookbooks to work on Ubuntu 14.04 and Apache 2.4 (default). 

Until the v2.4 changes are merged on the apache2 side, the COOK-3900 branch of the apache2 cookbook must be used, and the node["apache"]["version"] attribute must be set to "2.4". 

Without this change, the Apache proxy will return a 403 error for all requests including the root and /setup
