### PR TITLE
Fix for "sh: 'rsync' no such file or directory" on RHEL-like systems

### DIFF
--- a/recipes/backup_client.rb
+++ b/recipes/backup_client.rb
@@ -2,6 +2,7 @@
 settings = Stash.settings(node)
 
 package 'unzip'
+package 'rsync'
 
 ark 'stash-backup-client' do
   url node['stash']['backup_client']['url']


### PR DESCRIPTION
The `ark` resource requires `rsync` package to be installed.

It fixes the next error (reproduced on "centos6" and "stash" cookbook version 3.12.1):
```
...
==> centos6: Mixlib::ShellOut::ShellCommandFailed
==> centos6: ------------------------------------
==> centos6: execute[unpack /var/chef/cache/stash-backup-client-1.5.0.zip] (/tmp/vagrant-chef-3/chef-solo-1/cookbooks/ark/providers/default.rb line 55) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '127'
==> centos6:
==> centos6: ---- Begin output of unzip -q -u -o /var/chef/cache/stash-backup-client-1.5.0.zip -d /tmp/d20141111-3706-192msdu && rsync -a /tmp/d20141111-3706-192msdu/*/ /opt/atlassian/stash-backup-client-1.5.0 && rm -rf /tmp/d20141111-3706-192msdu ----
==> centos6:
==> centos6: STDOUT:
==> centos6:
==> centos6: STDERR: sh: rsync: command not found
==> centos6:
==> centos6: ---- End output of unzip -q -u -o /var/chef/cache/stash-backup-client-1.5.0.zip -d /tmp/d20141111-3706-192msdu && rsync -a /tmp/d20141111-3706-192msdu/*/ /opt/atlassian/stash-backup-client-1.5.0 && rm -rf /tmp/d20141111-3706-192msdu ----
==> centos6:
==> centos6: Ran unzip -q -u -o /var/chef/cache/stash-backup-client-1.5.0.zip -d /tmp/d20141111-3706-192msdu && rsync -a /tmp/d20141111-3706-192msdu/*/ /opt/atlassian/stash-backup-client-1.5.0 && rm -rf /tmp/d20141111-3706-192msdu returned 127...
```
