### PR TITLE
Fixes for the Stash library

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -152,8 +152,6 @@ default['stash']['backup_client']['cron']['weekday'] = '*'
 default['stash']['database']['host']     = 'localhost'
 default['stash']['database']['name']     = 'stash'
 default['stash']['database']['password'] = 'changeit'
-default['stash']['database']['port']     = 3306
-default['stash']['database']['testInterval'] = 2
 default['stash']['database']['type']     = 'mysql'
 default['stash']['database']['user']     = 'stash'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -152,6 +152,7 @@ default['stash']['backup_client']['cron']['weekday'] = '*'
 default['stash']['database']['host']     = 'localhost'
 default['stash']['database']['name']     = 'stash'
 default['stash']['database']['password'] = 'changeit'
+default['stash']['database']['testInterval'] = 2
 default['stash']['database']['type']     = 'mysql'
 default['stash']['database']['user']     = 'stash'
 

--- a/libraries/stash.rb
+++ b/libraries/stash.rb
@@ -20,7 +20,7 @@ class Chef
             end
           end
         ensure
-          settings ||= node['stash']
+          settings ||= node['stash'].to_hash
           settings['database']['port'] ||= Stash.default_database_port(settings['database']['type'])
           settings['database']['testInterval'] ||= 2
         end

--- a/libraries/stash.rb
+++ b/libraries/stash.rb
@@ -5,24 +5,24 @@ class Chef
     # Chef::Recipe::Stash class
     class Stash
       def self.settings(node)
+        settings = node['stash'].to_hash
+
         begin
           if Chef::Config[:solo]
             begin
-              settings = Chef::DataBagItem.load('stash', 'stash')['local']
+              settings.merge! Chef::DataBagItem.load('stash', 'stash')['local']
             rescue
               Chef::Log.info('No stash data bag found')
             end
           else
             begin
-              settings = Chef::EncryptedDataBagItem.load('stash', 'stash')[node.chef_environment]
+              settings.merge! Chef::EncryptedDataBagItem.load('stash', 'stash')[node.chef_environment]
             rescue
               Chef::Log.info('No stash encrypted data bag found')
             end
           end
         ensure
-          settings ||= node['stash'].to_hash
           settings['database']['port'] ||= Stash.default_database_port(settings['database']['type'])
-          settings['database']['testInterval'] ||= 2
         end
 
         settings

--- a/libraries/stash.rb
+++ b/libraries/stash.rb
@@ -21,14 +21,14 @@ class Chef
           end
         ensure
           settings ||= node['stash']
-          settings['database']['port'] ||= default_database_port settings['database']['type']
+          settings['database']['port'] ||= Stash.default_database_port(settings['database']['type'])
           settings['database']['testInterval'] ||= 2
         end
 
         settings
       end
 
-      def default_database_port(type)
+      def self.default_database_port(type)
         case type
         when 'mysql'
           3306


### PR DESCRIPTION
##### 1. Default settings should not be specified in attribute files 
`Chef::Recipe::Stash.settings` method is going to set default settings:
```
settings ||= node['stash']
settings['database']['port'] ||= default_database_port settings['database']['type']
settings['database']['testInterval'] ||= 2
```
But it will never be done because the node will always have these attributes specified in `attributes/default.rb`. 
For example, even if we set `['database']['type'] = 'postgresql'`, the port will be "3306" anyway. So that, these attributes should not be specified in attribute file.

##### 2. `default_database_port ` method is unavailable
This method should be a class method, instead of an instance method. Otherwise, it can not be called from `Chef::Recipe::Stash.settings` method 

##### 3. `settings` should be a hash.
While copying `settings ||= node['stash']` it should be also converted to Hash object, becouse Node object is read-only and overriding below will be unavailable. 