### PR TITLE
Fixed HTTP authentication

### DIFF
--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -6,4 +6,9 @@ include_recipe 'apache2::mod_proxy'
 include_recipe 'apache2::mod_proxy_http'
 include_recipe 'apache2::mod_ssl'
 
+# Disable mod_auth_basic because it isn't supported in Stash 2.10 and later
+apache_module "auth_basic" do
+  enable false
+end
+
 web_app node['stash']['apache2']['virtual_host_name']

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -13,13 +13,10 @@
 	<% end -%>
 	<% end -%>
 	DocumentRoot <%= node['stash']['install_path'] %>
-	
+
 	CustomLog <%= node['stash']['apache2']['access_log'].empty? ? node['apache']['log_dir']+"/stash-access.log" : node['stash']['apache2']['access_log'] %> combined
 	ErrorLog <%= node['stash']['apache2']['error_log'].empty? ? node['apache']['log_dir']+"/stash-error.log" : node['stash']['apache2']['error_log'] %>
 	LogLevel warn
-
-    # Make sure we disable/prevent basic authentication attempts since Stash 2.1+ can't handle them
-    RequestHeader unset Authorization
 
 	<Proxy *>
     <% if node['apache'] && node['apache']['version'] == '2.4' %>
@@ -48,9 +45,6 @@
 	CustomLog <%= node['stash']['apache2']['ssl']['access_log'].empty? ? node['apache']['log_dir']+"/stash-ssl-access.log" : node['stash']['apache2']['ssl']['access_log'] %> combined
 	ErrorLog <%= node['stash']['apache2']['ssl']['error_log'].empty? ? node['apache']['log_dir']+"/stash-ssl-error.log" : node['stash']['apache2']['ssl']['error_log'] %>
 	LogLevel warn
-
-    # Make sure we disable/prevent basic authentication attempts since Stash 2.1+ can't handle them
-    RequestHeader unset Authorization
 
 	<Proxy *>
     <% if node['apache'] && node['apache']['version'] == '2.4' %>


### PR DESCRIPTION
Rolls back #36 
Fixes #42

`Authorization` header should not be removed. It's enough to disable `auth_basic` module.

cc:\ @linc01n @martianus 