### PR TITLE
Allow disabling of SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ keyAlias | Tomcat SSL keystore alias | String | tomcat
 keystoreFile | Tomcat SSL keystore file - will automatically generate self-signed keystore file if left as default | String | `#{node['stash']['home_path']}/.keystore`
 keystorePass | Tomcat SSL keystore passphrase | String | changeit
 port | Tomcat HTTP port | Fixnum | 7990
-ssl_port | Tomcat HTTPS port | Fixnum | 8443
+ssl_port | Tomcat HTTPS port - HTTPS will be disabled, if set to a "false" value (e.g. -1) | Fixnum | 8443
 
 ## Recipes
 

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -1,5 +1,7 @@
 node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['port'])
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['ssl']['port'])
+unless node['apache']['listen_ports'].include?(node['stash']['apache2']['ssl']['port']) || !node['stash']['apache2']['ssl']['port']
+  node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['ssl']['port']]
+end
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -29,7 +29,7 @@ execute 'Generating Self-Signed Java Keystore' do
     chown #{node['stash']['user']}:#{node['stash']['user']} #{settings['tomcat']['keystoreFile']}
   COMMAND
   creates settings['tomcat']['keystoreFile']
-  only_if { settings['tomcat']['keystoreFile'] == "#{node['stash']['home_path']}/.keystore" }
+  only_if { settings['tomcat']['keystoreFile'] == "#{node['stash']['home_path']}/.keystore" && settings['tomcat']['ssl_port'] }
 end
 
 directory node['stash']['install_path'] do

--- a/templates/default/server-tomcat7.xml.erb
+++ b/templates/default/server-tomcat7.xml.erb
@@ -97,6 +97,7 @@
                    connectionTimeout="20000"
                    redirectPort="8443" />
         -->
+        <%- if node['stash']['tomcat']['ssl_port'] %>
         <!-- Define a SSL HTTP/1.1 Connector on port 8443
              This connector uses the JSSE configuration, when using APR, the
              connector should be using the OpenSSL style configuration
@@ -121,6 +122,7 @@
              <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
              <%- end %>
         />
+        <%- end %>
         <!--
         <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                    maxThreads="150" scheme="https" secure="true"

--- a/templates/default/server-tomcat8.xml.erb
+++ b/templates/default/server-tomcat8.xml.erb
@@ -95,6 +95,7 @@
                    connectionTimeout="20000"
                    redirectPort="8443" />
         -->
+        <%- if node['stash']['tomcat']['ssl_port'] %>
         <!-- Define a SSL HTTP/1.1 Connector on port 8443
              This connector uses the JSSE configuration, when using APR, the
              connector should be using the OpenSSL style configuration
@@ -119,6 +120,7 @@
              <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
              <%- end %>
         />
+        <%- end %>
         <!--
         <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                    maxThreads="150" scheme="https" secure="true"

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -91,6 +91,7 @@
                    connectionTimeout="20000"
                    redirectPort="8443" />
         -->
+        <%- if node['stash']['tomcat']['ssl_port'] %>
         <!-- Define a SSL HTTP/1.1 Connector on port 8443
              This connector uses the JSSE configuration, when using APR, the
              connector should be using the OpenSSL style configuration
@@ -116,6 +117,7 @@
              <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
              <%- end %>
         />
+        <%- end %>
 
         <!--
         <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"

--- a/templates/default/web-tomcat7.xml.erb
+++ b/templates/default/web-tomcat7.xml.erb
@@ -4280,6 +4280,7 @@
         <welcome-file>index.jsp</welcome-file>
     </welcome-file-list>
 
+    <%- if node['stash']['tomcat']['ssl_port'] %>
     <!-- Require HTTPS for login -->
       <security-constraint>
          <web-resource-collection>
@@ -4290,4 +4291,5 @@
               <transport-guarantee>CONFIDENTIAL</transport-guarantee>
          </user-data-constraint>
      </security-constraint>
+    <%- end %>
 </web-app>

--- a/templates/default/web.xml.erb
+++ b/templates/default/web.xml.erb
@@ -1202,6 +1202,7 @@
         <welcome-file>index.jsp</welcome-file>
     </welcome-file-list>
 
+     <%- if node['stash']['tomcat']['ssl_port'] %>
      <!-- Require HTTPS for login -->
       <security-constraint>
          <web-resource-collection>
@@ -1212,4 +1213,5 @@
               <transport-guarantee>CONFIDENTIAL</transport-guarantee>
          </user-data-constraint>
      </security-constraint>
+    <%- end %>
 </web-app>

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -30,6 +30,7 @@
 	ProxyPassReverse / http://localhost:<%= node['stash']['tomcat']['port'] %>/
 </VirtualHost>
 
+<%- if node['stash']['apache2']['ssl']['port'] %>
 <VirtualHost *:<%= node['stash']['apache2']['ssl']['port'] %>>
 	<% unless node['stash']['apache2']['virtual_host_name'].empty? -%>
 	ServerName <%= node['stash']['apache2']['virtual_host_name'] %>
@@ -64,3 +65,4 @@
 	SSLCertificateChainFile <%= node['stash']['apache2']['ssl']['chain_file'] %>
 	<% end -%>
 </VirtualHost>
+<% end -%>


### PR DESCRIPTION
Allows to disable to the SSL configuration of Tomcat and Apache by setting the port attributes to `-1`.

It is a replacement for PR #22 with the difference, that a34d15db1de390c4ece8ab94059d4f7f9ce5f419 (add proxy preserve host) has not been applied as it is unrelated to SSL (but important nevertheless).