### PR TITLE
Fixed deprecation warning from Berkshelf

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
 


### PR DESCRIPTION
Since there is an outdated directive in Berksfile, we have the following warning from the resent "berks":


>DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "https://supermarket.chef.io"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations

So, this pull-request fixes that warning.