### PR TITLE
Set home path to 3.x default when it exists

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,12 @@ set['build-essential']['compile_time'] = true
 default['stash']['version']      = '4.1.0'
 default['stash']['product']      = Chef::Version.new(node['stash']['version']) >= Chef::Version.new('4.0.0') ? 'bitbucket' : 'stash'
 
-default['stash']['home_path']    = "/var/atlassian/application-data/#{node['stash']['product']}"
+if Dir.exist?('/var/atlassian/application-data/stash')
+  default['stash']['home_path']    = '/var/atlassian/application-data/stash'
+else
+  default['stash']['home_path']    = "/var/atlassian/application-data/#{node['stash']['product']}"
+end
+
 default['stash']['install_path'] = '/opt/atlassian'
 default['stash']['install_type'] = 'standalone'
 default['stash']['service_type'] = 'init'

--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -22,6 +22,12 @@ if stash_version >= Chef::Version.new('3.2.0')
     action :create
     recursive true
   end
+
+  bash 'update home path permission' do
+    code <<-EOH
+      chown -R #{node['stash']['user']}:#{node['stash']['user']} #{node['stash']['home_path']}
+    EOH
+  end
 else
   config_path = '/stash-config.properties'
 end


### PR DESCRIPTION
- set directory to right permission

If users are upgrading from 3.x cookbook to 4.x, we should not change the repo data path.
Users may have other external script using that path.