### PR TITLE
.kitchen.yml: Rename Vagrant boxes "chef" -> "bento"

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,22 +12,22 @@ driver_config:
 platforms:
 - name: centos-6.7
   driver_config:
-    box: chef/centos-6.7
+    box: bento/centos-6.7
   run_list:
   - recipe[yum]
 - name: centos-7.1
   driver_config:
-    box: chef/centos-7.1
+    box: bento/centos-7.1
   run_list:
   - recipe[yum]
 - name: ubuntu-12.04
   driver_config:
-    box: chef/ubuntu-12.04
+    box: bento/ubuntu-12.04
   run_list:
   - recipe[apt]
 - name: ubuntu-14.04
   driver_config:
-    box: chef/ubuntu-14.04
+    box: bento/ubuntu-14.04
   run_list:
   - recipe[apt]
 


### PR DESCRIPTION
All Vagrant boxes from "chef" account on Atlas have been moved to the "bento" namespace:
https://atlas.hashicorp.com/chef

P.s. By the way, is it still reasonable to freeze Chef Client version in `.kitchen.yml`?
```
require_chef_omnibus: 11.16.2
```
https://github.com/bflad/chef-stash/blob/8c8dda6b5b25873bd87a8e5c2de75168a1b05adc/.kitchen.yml#L4