### PR TITLE
Disable https on the Tomcat side

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,9 @@ uri | Stash SSH URI | String | `ssh://git@#{node['stash']['ssh']['hostname']}:#{
 
 These attributes are under the `node['stash']['tomcat']` namespace.
 
-Any `node['stash']['tomcat']['key*']` attributes are overridden by `stash/stash` encrypted data bag (Hosted Chef) or data bag (Chef Solo), if it exists
-
 Attribute | Description | Type | Default
 ----------|-------------|------|--------
-keyAlias | Tomcat SSL keystore alias | String | tomcat
-keystoreFile | Tomcat SSL keystore file - will automatically generate self-signed keystore file if left as default | String | `#{node['stash']['home_path']}/.keystore`
-keystorePass | Tomcat SSL keystore passphrase | String | changeit
 port | Tomcat HTTP port | Fixnum | 7990
-ssl_port | Tomcat HTTPS port | Fixnum | 8443
 
 ## Recipes
 
@@ -214,9 +208,6 @@ _optional:_
 * `['database']['port']` Database port, standard database port for
   `['database']['type']`
 * `['plugin']['KEY']` plugin.`KEY`=`VALUE` to be inserted in stash-config.properties
-* `['tomcat']['keyAlias']` Tomcat HTTPS Java Keystore keyAlias, defaults to self-signed certifcate
-* `['tomcat']['keystoreFile']` Tomcat HTTPS Java Keystore keystoreFile, self-signed certificate
-* `['tomcat']['keystorePass']` Tomcat HTTPS Java Keystore keystorePass, self-signed certificate
 
 Repeat for other Chef environments as necessary. Example:
 
@@ -229,11 +220,6 @@ Repeat for other Chef environments as necessary. Example:
           "name": "stash",
           "user": "stash",
           "password": "stash_db_password",
-        },
-        "tomcat": {
-          "keyAlias": "not_tomcat",
-          "keystoreFile": "/etc/pki/java/wildcard_cert.jks",
-          "keystorePass": "not_changeit"
         }
       }
     }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -261,8 +261,4 @@ default['stash']['properties'] = {}
 default['stash']['ssh']['hostname'] = node['fqdn']
 default['stash']['ssh']['port']     = '7999'
 
-default['stash']['tomcat']['keyAlias']     = 'tomcat'
-default['stash']['tomcat']['keystoreFile'] = "#{node['stash']['home_path']}/.keystore"
-default['stash']['tomcat']['keystorePass'] = 'changeit'
-default['stash']['tomcat']['port']         = '7990'
-default['stash']['tomcat']['ssl_port']     = '8443'
+default['stash']['tomcat']['port'] = '7990'

--- a/recipes/linux_standalone.rb
+++ b/recipes/linux_standalone.rb
@@ -17,21 +17,6 @@ user node['stash']['user'] do
   action :create
 end
 
-execute 'Generating Self-Signed Java Keystore' do
-  command <<-COMMAND
-    #{node['java']['java_home']}/bin/keytool -genkey \
-      -alias #{settings['tomcat']['keyAlias']} \
-      -keyalg RSA \
-      -dname 'CN=#{node['fqdn']}, OU=Example, O=Example, L=Example, ST=Example, C=US' \
-      -keypass #{settings['tomcat']['keystorePass']} \
-      -storepass #{settings['tomcat']['keystorePass']} \
-      -keystore #{settings['tomcat']['keystoreFile']}
-    chown #{node['stash']['user']}:#{node['stash']['user']} #{settings['tomcat']['keystoreFile']}
-  COMMAND
-  creates settings['tomcat']['keystoreFile']
-  only_if { settings['tomcat']['keystoreFile'] == "#{node['stash']['home_path']}/.keystore" }
-end
-
 directory node['stash']['install_path'] do
   owner 'root'
   group 'root'

--- a/recipes/tomcat_configuration.rb
+++ b/recipes/tomcat_configuration.rb
@@ -1,4 +1,3 @@
-settings = Stash.settings(node)
 stash_version = Chef::Version.new(node['stash']['version'])
 server_xml_path = "#{node['stash']['install_path']}/stash/conf/server.xml"
 
@@ -33,7 +32,6 @@ template server_xml_path do
   end
   owner node['stash']['user']
   mode '0640'
-  variables :tomcat => settings['tomcat']
   notifies :restart, "service[#{node['stash']['product']}]", :delayed
 end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,6 +2,41 @@ require 'spec_helper'
 
 describe 'stash::default' do
   let(:chef_run) do
-    ChefSpec::Runner.new.converge(described_recipe)
+    ChefSpec::SoloRunner.new do |node|
+      node.set['stash']['install_path'] = '/opt/atlassian'
+      node.set['stash']['home_path'] = '/var/atlassian/application-data/bitbucket'
+      node.set['postgresql']['password']['postgres'] = 'postgres_pass'
+    end.converge(described_recipe)
+  end
+
+  before do
+    # Required for 'apache2::default' converge
+    stub_command('/usr/sbin/apache2 -t').and_return(true)
+
+    # Required for 'postgresql::server' converge
+    stub_command(%r{ls \/.*\/recovery.conf}).and_return(false)
+  end
+
+  it 'renders server.xml' do
+    path = '/var/atlassian/application-data/bitbucket/shared/server.xml'
+    resource = chef_run.template(path)
+
+    expect(resource).to notify('service[bitbucket]').to(:restart)
+    expect(chef_run).to render_file(path)
+  end
+
+  it 'renders web.xml' do
+    path = '/opt/atlassian/bitbucket/conf/web.xml'
+    resource = chef_run.template(path)
+
+    expect(resource).to notify('service[bitbucket]').to(:restart)
+    expect(chef_run).to render_file(path)
+  end
+
+  it 'renders setenv.sh' do
+    expect(chef_run).to render_file('/opt/atlassian/bitbucket/bin/setenv.sh')
+      .with_content { |content|
+        expect(content).to include('export BITBUCKET_HOME="/var/atlassian/application-data/bitbucket"')
+      }
   end
 end

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -74,15 +74,11 @@
                    useBodyEncodingForURI="true"
                    compression="on"
                    compressableMimeType="text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
-                   <% if node['stash']['apache2'] -%>
-                   redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
                    proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
-                   <% else -%>
-                   redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"
-                   <% end -%>
+                   redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    />
         <!-- A "Connector" using the shared thread pool-->
         <!--
@@ -95,28 +91,6 @@
              This connector uses the JSSE configuration, when using APR, the
              connector should be using the OpenSSL style configuration
              described in the APR documentation -->
-
-        <Connector port="<%= node['stash']['tomcat']['ssl_port'] %>"
-             maxHttpHeaderSize="8192"
-             SSLEnabled="true"
-             maxThreads="150"
-             minSpareThreads="25"
-             maxSpareThreads="75"
-             enableLookups="false"
-             disableUploadTimeout="true"
-             useBodyEncodingForURI="true"
-             acceptCount="100"
-             scheme="https"
-             secure="true"
-             clientAuth="false"
-             sslProtocol="TLS"
-             <%- if @tomcat %>
-             <%= "keyAlias=\"#{@tomcat['keyAlias']}\"" if @tomcat['keyAlias'] %>
-             <%= "keystoreFile=\"#{@tomcat['keystoreFile']}\"" if @tomcat['keystoreFile'] %>
-             <%= "keystorePass=\"#{@tomcat['keystorePass']}\"" if @tomcat['keystorePass'] %>
-             <%- end %>
-        />
-
         <!--
         <Connector port="8443" protocol="HTTP/1.1" SSLEnabled="true"
                    maxThreads="150" scheme="https" secure="true"

--- a/test/integration/mysql/serverspec/linux_standalone_spec.rb
+++ b/test/integration/mysql/serverspec/linux_standalone_spec.rb
@@ -4,10 +4,3 @@ describe user($node['stash']['user']) do
   it { should exist }
   it { should have_home_directory $node['stash']['home_path'] }
 end
-
-# Java keystore
-describe file("#{$node['stash']['home_path']}/.keystore") do
-  it { should exist }
-  it { should be_file }
-  it { should be_owned_by $node['stash']['user'] }
-end

--- a/test/integration/mysql/serverspec/service_init_spec.rb
+++ b/test/integration/mysql/serverspec/service_init_spec.rb
@@ -14,7 +14,3 @@ end
 describe port($node['stash']['tomcat']['port']) do
   it { should be_listening }
 end
-
-describe port($node['stash']['tomcat']['ssl_port']) do
-  it { should be_listening }
-end

--- a/test/integration/postgresql/serverspec/linux_standalone_spec.rb
+++ b/test/integration/postgresql/serverspec/linux_standalone_spec.rb
@@ -4,10 +4,3 @@ describe user($node['stash']['user']) do
   it { should exist }
   it { should have_home_directory $node['stash']['home_path'] }
 end
-
-# Java keystore
-describe file("#{$node['stash']['home_path']}/.keystore") do
-  it { should exist }
-  it { should be_file }
-  it { should be_owned_by $node['stash']['user'] }
-end

--- a/test/integration/postgresql/serverspec/service_init_spec.rb
+++ b/test/integration/postgresql/serverspec/service_init_spec.rb
@@ -14,7 +14,3 @@ end
 describe port($node['stash']['tomcat']['port']) do
   it { should be_listening }
 end
-
-describe port($node['stash']['tomcat']['ssl_port']) do
-  it { should be_listening }
-end


### PR DESCRIPTION
*The similar PRs were merged to JIRA and Confluence cookbooks: *
afklm/jira#30 
https://github.com/parallels-cookbooks/confluence/pull/68

Production instances of Bitbucket Server (and Stash) usually use some web server as a reverse proxy at the front of Tomcat.
In this cookbook we also configure Apache web server for these needs.

So, since https is actually terminating on the Apache side, there are no needs to manage keystore
and configure TLS/SSL on the Tomcat side.

*UPDATE:*
Closes #56