### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -18,16 +18,9 @@
 	ErrorLog <%= node['stash']['apache2']['error_log'].empty? ? node['apache']['log_dir']+"/stash-error.log" : node['stash']['apache2']['error_log'] %>
 	LogLevel warn
 
-	<Proxy *>
-    <% if node['apache'] && node['apache']['version'] == '2.4' %>
-		Require all granted
-    <% else %>
-		Order Deny,Allow
-		Allow from all
-    <% end %>
-	</Proxy>
-	ProxyPass        / http://localhost:<%= node['stash']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
-	ProxyPassReverse / http://localhost:<%= node['stash']['tomcat']['port'] %>/
+	RewriteEngine On
+	RewriteCond %{HTTPS} off
+	RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
 
 <VirtualHost *:<%= node['stash']['apache2']['ssl']['port'] %>>


### PR DESCRIPTION
*Similar changes were merged to JIRA and Confluence cookbooks:*
https://github.com/afklm/jira/pull/39
https://github.com/parallels-cookbooks/confluence/pull/73

We use Apache web server in the front of Tomcat.
Since we configure SSL in Apache by default, we can also add a rewrite rule to the virtual host configuration in order to force HTTPS.
And we don't need to configure proxy for HTTP-based virtual host anymore.