### PR TITLE
Set database type when running mysql suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,10 +47,14 @@ suites:
   - recipe[stash]
   attributes:
     <<: *DEFAULT_ATTRIBUTES
+    stash:
+      database:
+        type: mysql
     mysql:
       server_root_password: iloverandompasswordsbutthiswilldo
       server_repl_password: iloverandompasswordsbutthiswilldo
       server_debian_password: iloverandompasswordsbutthiswilldo
+
 - name: postgresql
   run_list:
   - recipe[test-helper]
@@ -58,9 +62,6 @@ suites:
   - recipe[stash]
   attributes:
     <<: *DEFAULT_ATTRIBUTES
-    stash:
-      database:
-        type: postgresql
     postgresql:
       password:
         postgres: iloverandompasswordsbutthiswilldo


### PR DESCRIPTION
We changed the default from `mysql` to `postgresql` after cookbook 4.0 release.
So we need to specify to use mysql database during `kitchen test`