### PR TITLE
Fix apache listen ports attribute

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'apache2'
+depends 'apache2', '>= 3.2.0'
 depends 'ark'
 depends 'cron'
 depends 'database'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -1,5 +1,7 @@
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['port'])
-node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['ssl']['port'])
+node.default['apache']['listen'] |= [
+  "*:#{node['stash']['apache2']['port']}",
+  "*:#{node['stash']['apache2']['ssl']['port']}"
+]
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'


### PR DESCRIPTION
In cookbook apache2 v3.2.0 the attribute was changed and renamed:
`node.default['apache']['listen_ports']` -> `node.default['apache']['listen']`

This change causes the following error with `apache2` cookbook 3.2.0 and higher:

```
         NoMethodError
         -------------
         undefined method `include?' for nil:NilClass

         Cookbook Trace:
         ---------------
           /tmp/kitchen/cache/cookbooks/stash/recipes/apache2.rb:1:in `from_file'
           /tmp/kitchen/cache/cookbooks/stash/recipes/default.rb:16:in `from_file'

         Relevant File Content:
         ----------------------
         /tmp/kitchen/cache/cookbooks/stash/recipes/apache2.rb:

           1>> node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['port'])
           2:  node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['ssl']['port'])
```

This PR fixes that issue.