### PR TITLE
Support multiple apache2 versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ supports 'redhat'
 supports 'scientific'
 supports 'ubuntu'
 
-depends 'apache2', '>= 3.2.0'
+depends 'apache2'
 depends 'ark'
 depends 'cron'
 depends 'database'

--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -1,7 +1,12 @@
-node.default['apache']['listen'] |= [
-  "*:#{node['stash']['apache2']['port']}",
-  "*:#{node['stash']['apache2']['ssl']['port']}"
-]
+begin
+  node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['port'])
+  node.set['apache']['listen_ports'] = node['apache']['listen_ports'] + [node['stash']['apache2']['ssl']['port']] unless node['apache']['listen_ports'].include?(node['stash']['apache2']['ssl']['port'])
+rescue NoMethodError
+  node.default['apache']['listen'] |= [
+    "*:#{node['stash']['apache2']['port']}",
+    "*:#{node['stash']['apache2']['ssl']['port']}"
+  ]
+end
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_proxy'


### PR DESCRIPTION
Remove apache2 pinning and wrap it inside a `begin...rescue` block

Related to #148 

/cc @bflad @legal90 