### PR TITLE
Bitbucket 4.6 needs set-bitbucket-home.sh and set-bitbucket-user.sh

### DIFF
--- a/recipes/tomcat_configuration.rb
+++ b/recipes/tomcat_configuration.rb
@@ -57,7 +57,19 @@ directory "/var/run/#{node['stash']['product']}" do
   action :create
 end
 
-template "#{node['stash']['install_path']}/bitbucket/bin/user.sh" do
+user_sh = 'user.sh'
+if stash_version >= Chef::Version.new('4.6.0')
+  user_sh = 'set-bitbucket-user.sh'
+
+  template "#{node['stash']['install_path']}/bitbucket/bin/set-bitbucket-home.sh" do
+    source 'bitbucket/set-bitbucket-home.sh.erb'
+    owner node['stash']['user']
+    mode '0755'
+    notifies :restart, "service[#{node['stash']['product']}]", :delayed
+  end
+end
+
+template "#{node['stash']['install_path']}/bitbucket/bin/#{user_sh}" do
   source 'bitbucket/user.sh.erb'
   owner node['stash']['user']
   mode '0755'

--- a/templates/default/bitbucket/set-bitbucket-home.sh.erb
+++ b/templates/default/bitbucket/set-bitbucket-home.sh.erb
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# One way to set the BITBUCKET_HOME path is here via this variable.  Simply uncomment it and set a valid path like
+# /bitbucket/home.  You can of course set it outside in the command terminal; that will also work.
+#
+
+if [ "x${BITBUCKET_HOME}" = "x" ]; then
+    export BITBUCKET_HOME="<%= node['stash']['home_path'] %>" # set by chef
+fi
+
+# When upgrading from the packaged distribution BITBUCKET_HOME may not be set. Fallback to legacy STASH_HOME
+# and output a message for the user recommending that they update their environment
+if [ "x${BITBUCKET_HOME}" = "x" ]; then
+    if [ ! "x${STASH_HOME}" = "x" ]; then
+        BITBUCKET_HOME=${STASH_HOME}
+        echo ""
+        echo "--------------------------------------------------------------------------------------"
+        echo "  WARNING: STASH_HOME has been deprecated and replaced with BITBUCKET_HOME."
+        echo "  We recommend you set BITBUCKET_HOME instead of STASH_HOME."
+        echo "  Future versions of Bitbucket may not support the STASH_HOME variable."
+        echo "--------------------------------------------------------------------------------------"
+    fi
+fi
+
+echo $BITBUCKET_HOME | grep -q " "
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "-------------------------------------------------------------------------------"
+    echo "  BITBUCKET_HOME \"$BITBUCKET_HOME\" contains spaces."
+    echo "  Using a directory with spaces is likely to cause unexpected behaviour and is"
+    echo "  not supported. Please use a directory which does not contain spaces."
+    echo "-------------------------------------------------------------------------------"
+    exit 1
+fi
+
+echo "BITBUCKET_HOME set to $BITBUCKET_HOME"


### PR DESCRIPTION
The setup scripts in $BITBUCKET_HOME/bin were refactored and now they call set-bitbucket-home.sh to set BITBUCKET_HOME and set-bitbucket-user.sh to set BITBUCKET_USER instead of user.sh.

Without this patch, a Bitbucket instance starts up under root. A bundled Elasticsearch instance can't run as root and fails to start. That's the reason code search doesn't work. You get behaviour like described here: https://jira.atlassian.com/browse/BSERV-8763 (Search is currently unavailable)

We need to have $BITBUCKET_HOME/bin/set-bitbucket-home.sh and $BITBUCKET_HOME/bin/set-bitbucket-user.sh instead of  $BITBUCKET_HOME/bin/user.sh for Bitbucket 4.6.0 and higher.

I tested the change with Bitbucket 4.6.2.

Fixes #156

@linc01n @bflad Please have a look