### PR TITLE
Run start-bitbucket.sh with the full path in Bitbucket init script

### DIFF
--- a/templates/default/bitbucket/bitbucket.init.erb
+++ b/templates/default/bitbucket/bitbucket.init.erb
@@ -25,11 +25,11 @@ if [ ! -d /var/run/bitbucket ]; then
 fi
 
 start() {
-    ./start-bitbucket.sh
+    $BASE/bin/start-bitbucket.sh
 }
 
 stop() {
-    ./stop-bitbucket.sh
+    $BASE/bin/stop-bitbucket.sh
 }
 
 status() {


### PR DESCRIPTION
After merging #157 I've converged a new bitbucket instance, and it seems that patch isn't enough to bring the code search up.

When I start Bitbucket manually, I get 'cannot stat' error and elasticsearch fails as log4j isn't configured properly (elasticsearch/config-template/ contains logging configuration). The result is the same -- 'Search is unavailable'.
```
/etc/init.d/bitbucket start
-------------------------------------------------------------------------------
Starting Atlassian Bitbucket and bundled Elasticsearch
To start Atlassian Bitbucket on its own, run start-webapp.sh instead
-------------------------------------------------------------------------------
Starting Elasticsearch bundled with Atlassian Bitbucket
BITBUCKET_HOME set to /var/atlassian/application-data/bitbucket
Starting Elasticsearch bundled with Atlassian Bitbucket as dedicated user stash 

cp: cannot stat `./../elasticsearch/config-template/*': No such file or directory

Elasticsearch bundled with Atlassian Bitbucket started successfully
```
The culprit is this line (in start-search.sh):
$sucmd -l $BITBUCKET_USER -c "mkdir -p \"$ES_CONFIG_PATH\" && cp -r \"$PRGDIR/../elasticsearch/config-template/\"* \"$ES_CONFIG_PATH\""

It copies logging configuration to where elasticsearch is set to look for it.

start-search.sh is called by start-bitbucket.sh, and start-bitbucket.sh is called by the init script:
```
start() {
    ./start-bitbucket.sh
}
```
So PRGDIR is ./. It looks like a bug in start-search.sh.
We can workaround by running $BASE/bin/start-bitbucket.sh instead of ./start-bitbucket.sh in the init script. Worked for me.