### PR TITLE
Enable setting the session timeout

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -298,3 +298,4 @@ default['stash']['ssh']['hostname'] = node['fqdn']
 default['stash']['ssh']['port']     = '7999'
 
 default['stash']['tomcat']['port'] = '7990'
+default['stash']['tomcat']['session-timeout'] = '30'

--- a/templates/default/3.8+/web.xml
+++ b/templates/default/3.8+/web.xml
@@ -512,7 +512,7 @@
   <!-- created sessions by modifying the value below.                       -->
 
     <session-config>
-        <session-timeout>30</session-timeout>
+        <session-timeout><%= node['stash']['tomcat']['session-timeout'] %></session-timeout>
     </session-config>
 
 

--- a/templates/default/bitbucket/web.xml
+++ b/templates/default/bitbucket/web.xml
@@ -562,7 +562,7 @@
   <!-- created sessions by modifying the value below.                       -->
 
     <session-config>
-        <session-timeout>30</session-timeout>
+        <session-timeout><%= node['stash']['tomcat']['session-timeout'] %></session-timeout>
     </session-config>
 
 

--- a/templates/default/web-tomcat7.xml.erb
+++ b/templates/default/web-tomcat7.xml.erb
@@ -506,7 +506,7 @@
   <!-- created sessions by modifying the value below.                       -->
 
     <session-config>
-        <session-timeout>30</session-timeout>
+        <session-timeout><%= node['stash']['tomcat']['session-timeout'] %></session-timeout>
     </session-config>
 
 

--- a/templates/default/web.xml.erb
+++ b/templates/default/web.xml.erb
@@ -495,7 +495,7 @@
   <!-- created sessions by modifying the value below.                       -->
 
     <session-config>
-        <session-timeout>30</session-timeout>
+        <session-timeout><%= node['stash']['tomcat']['session-timeout'] %></session-timeout>
     </session-config>
 
 


### PR DESCRIPTION
In order to be able to dynamically control the timeout of the tomcat's session, I moved it to an attribute.