### PR TITLE
Add attribute to be able to control the bitbucket service

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default['stash']['home_path'] = if Dir.exist?('/var/atlassian/application-data/s
 default['stash']['install_path'] = '/opt/atlassian'
 default['stash']['install_type'] = 'standalone'
 default['stash']['service_type'] = 'init'
+default['stash']['active_service'] = true
 default['stash']['url_base']     = "http://www.atlassian.com/software/stash/downloads/binary/atlassian-#{node['stash']['product']}"
 default['stash']['user']         = node['stash']['product']
 

--- a/recipes/service_init.rb
+++ b/recipes/service_init.rb
@@ -25,4 +25,5 @@ service node['stash']['product'] do
   supports :status => true, :restart => true
   action [:enable]
   subscribes :restart, 'java_ark[jdk]'
+  only_if { node['stash']['active_service'] }
 end


### PR DESCRIPTION
If the new attribute will stay set to 'true', no changes will be made to the cookbook or the server installation.
If it will be changed to 'false' -
1. The bitbucket service won't be enabled on boot.
2. All restart notifications from config files won't really restart the service.
3. Future start\restart notification won't change the service's state.

All those will result in a installed bitbucket server, but with stopped service.
And basically it will now enable installing a cold standby server as described here:
https://confluence.atlassian.com/bitbucketserver/high-availability-for-bitbucket-server-776640137.html