### PR TITLE
Support multiple virtual hosts

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -174,7 +174,8 @@ default['stash']['data_bag_item'] = 'stash'
 default['stash']['apache2']['access_log']         = ''
 default['stash']['apache2']['error_log']          = ''
 default['stash']['apache2']['port']               = 80
-default['stash']['apache2']['virtual_host_alias'] = node['fqdn']
+default['stash']['apache2']['virtual_host_primary'] = node['fqdn']
+default['stash']['apache2']['virtual_host_alias'] = node['stash']['apache2']['virtual_host_primary']
 default['stash']['apache2']['virtual_host_name']  = node['hostname']
 
 default['stash']['apache2']['ssl']['access_log']       = ''

--- a/templates/default/3.8+/server.xml.erb
+++ b/templates/default/3.8+/server.xml.erb
@@ -81,7 +81,7 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['stash']['apache2']['virtual_host_primary'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"

--- a/templates/default/bitbucket/server.xml.erb
+++ b/templates/default/bitbucket/server.xml.erb
@@ -81,7 +81,7 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['stash']['apache2']['virtual_host_primary'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"

--- a/templates/default/server-tomcat7.xml.erb
+++ b/templates/default/server-tomcat7.xml.erb
@@ -83,7 +83,7 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['stash']['apache2']['virtual_host_primary'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"

--- a/templates/default/server-tomcat8.xml.erb
+++ b/templates/default/server-tomcat8.xml.erb
@@ -81,7 +81,7 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['stash']['apache2']['virtual_host_primary'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -76,7 +76,7 @@
                    compressableMimeType="text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= node['stash']['apache2']['virtual_host_primary'] %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    />


### PR DESCRIPTION
Fully implement the support of several apache host aliases, by adding one primary URL.
This primary URL will be used in the server.xml, and now the virtual_host_alias can be really be an array.