### PR TITLE
Add the ability to change web_app template source

### DIFF
--- a/recipes/apache2.rb
+++ b/recipes/apache2.rb
@@ -19,4 +19,7 @@ apache_module 'auth_basic' do
   enable false
 end
 
-web_app node['stash']['apache2']['virtual_host_name']
+web_app node['stash']['apache2']['virtual_host_name'] do
+  template node['stash']['apache2']['webapp_template'] if node['stash']['apache2']['webapp_template']
+  cookbook node['stash']['apache2']['webapp_cookbook'] if node['stash']['apache2']['webapp_cookbook']
+end


### PR DESCRIPTION
When using a wrapper cookbook, we would like the ability to override the default web_app template.
This will allow it, when adding node['stash']['apache2']['webapp_template'] and node['stash']['apache2']['webapp_cookbook'] attributes.
(Based on apache2 cookbook web_app definition)