### PR TITLE
Enable multiple tomcat connectors

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -174,7 +174,7 @@ default['stash']['data_bag_item'] = 'stash'
 default['stash']['apache2']['access_log']         = ''
 default['stash']['apache2']['error_log']          = ''
 default['stash']['apache2']['port']               = 80
-default['stash']['apache2']['virtual_host_alias'] = node['fqdn']
+default['stash']['apache2']['virtual_host_alias'] = [node['fqdn']]
 default['stash']['apache2']['virtual_host_name']  = node['hostname']
 
 default['stash']['apache2']['ssl']['access_log']       = ''
@@ -295,7 +295,7 @@ default['stash']['plugin'] = {}
 default['stash']['properties'] = {}
 
 default['stash']['ssh']['hostname'] = node['fqdn']
-default['stash']['ssh']['port']     = '7999'
+default['stash']['ssh']['port']     = '7989'
 
-default['stash']['tomcat']['port'] = '7990'
+default['stash']['tomcat']['base-port'] = 7990
 default['stash']['tomcat']['session-timeout'] = '30'

--- a/recipes/tomcat_configuration.rb
+++ b/recipes/tomcat_configuration.rb
@@ -1,3 +1,10 @@
+# Create tomcat port to proxy name mapping
+# Creating it in recipe will allow tomcat connection changes when overriding ['stash']['apache2']['virtual_host_alias']
+node['stash']['apache2']['virtual_host_alias'].each_with_index do |cname,index|
+  port = node['stash']['tomcat']['base-port'] + index
+  node.default['stash']['tomcat']['connections'][port] = cname
+end
+
 # frozen_string_literal: true
 stash_version = Chef::Version.new(node['stash']['version'])
 server_xml_path = "#{node['stash']['install_path']}/stash/conf/server.xml"

--- a/templates/default/3.8+/server.xml.erb
+++ b/templates/default/3.8+/server.xml.erb
@@ -72,7 +72,8 @@
              If you change this port, you have to update scripts.cfg as well
              to have the same port configuration.
         -->
-        <Connector port="<%= node['stash']['tomcat']['port'] %>" protocol="HTTP/1.1"
+        <% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
+        <Connector port="<%= port %>" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    compression="on"
@@ -81,12 +82,13 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= proxy_name %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"
                    <% end -%>
                    />
+        <% end %>
 
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/templates/default/bitbucket/server.xml.erb
+++ b/templates/default/bitbucket/server.xml.erb
@@ -72,7 +72,8 @@
              If you change this port, you have to update scripts.cfg as well
              to have the same port configuration.
         -->
-        <Connector port="<%= node['stash']['tomcat']['port'] %>" protocol="HTTP/1.1"
+        <% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
+        <Connector port="<%= port %>" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    compression="on"
@@ -81,12 +82,13 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= proxy_name %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"
                    <% end -%>
                    />
+        <% end %>
 
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/templates/default/server-tomcat7.xml.erb
+++ b/templates/default/server-tomcat7.xml.erb
@@ -74,7 +74,8 @@
              If you change this port, you have to update scripts.cfg as well
              to have the same port configuration. 
         -->
-        <Connector port="<%= node['stash']['tomcat']['port'] %>" protocol="HTTP/1.1"
+        <% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
+        <Connector port="<%= port %>" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    compression="on"
@@ -83,12 +84,13 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= proxy_name %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"
                    <% end -%>
                    />
+        <% end %>
 
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/templates/default/server-tomcat8.xml.erb
+++ b/templates/default/server-tomcat8.xml.erb
@@ -72,7 +72,8 @@
              If you change this port, you have to update scripts.cfg as well
              to have the same port configuration.
         -->
-        <Connector port="<%= node['stash']['tomcat']['port'] %>" protocol="HTTP/1.1"
+        <% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
+        <Connector port="<%= port %>" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    compression="on"
@@ -81,12 +82,13 @@
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= proxy_name %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    <% else -%>
                    redirectPort="<%= node['stash']['tomcat']['ssl_port'] %>"
                    <% end -%>
                    />
+        <% end -%>
 
         <!-- A "Connector" using the shared thread pool-->
         <!--

--- a/templates/default/server.xml.erb
+++ b/templates/default/server.xml.erb
@@ -69,17 +69,19 @@
              APR (HTTP/AJP) Connector: /docs/apr.html
              Define a non-SSL HTTP/1.1 Connector on port 7990
         -->
-        <Connector port="<%= node['stash']['tomcat']['port'] %>" protocol="HTTP/1.1"
+        <% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
+        <Connector port="<%= port %>" protocol="HTTP/1.1"
                    connectionTimeout="20000"
                    useBodyEncodingForURI="true"
                    compression="on"
                    compressableMimeType="text/html,text/xml,text/plain,text/css,application/json,application/javascript,application/x-javascript"
                    secure="true"
                    scheme="https"
-                   proxyName="<%= node['stash']['apache2']['virtual_host_alias'] %>"
+                   proxyName="<%= proxy_name %>"
                    proxyPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    redirectPort="<%= node['stash']['apache2']['ssl']['port'] %>"
                    />
+        <% end %>
         <!-- A "Connector" using the shared thread pool-->
         <!--
         <Connector executor="tomcatThreadPool"

--- a/templates/default/web_app.conf.erb
+++ b/templates/default/web_app.conf.erb
@@ -24,16 +24,12 @@
 	RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 </VirtualHost>
 
+<% node['stash']['tomcat']['connections'].each do |port,proxy_name| %>
 <VirtualHost *:<%= node['stash']['apache2']['ssl']['port'] %>>
 	<% unless node['stash']['apache2']['virtual_host_name'].empty? -%>
 	ServerName <%= node['stash']['apache2']['virtual_host_name'] %>
 	<% end -%>
-	<% unless node['stash']['apache2']['virtual_host_alias'].empty? -%>
-	<% virtual_host_aliases = node['stash']['apache2']['virtual_host_alias'].kind_of?(Array) ? node['stash']['apache2']['virtual_host_alias'] : [ node['stash']['apache2']['virtual_host_alias'] ] -%>
-	<% virtual_host_aliases.each do |virtual_host_alias| -%>
-	ServerAlias <%= virtual_host_alias %>
-	<% end -%>
-	<% end -%>
+  ServerAlias <%= proxy_name %>
 	DocumentRoot <%= node['stash']['install_path'] %>
 
 	CustomLog <%= node['stash']['apache2']['ssl']['access_log'].empty? ? node['apache']['log_dir']+"/stash-ssl-access.log" : node['stash']['apache2']['ssl']['access_log'] %> combined
@@ -48,8 +44,8 @@
 		Allow from all
     <% end %>
 	</Proxy>
-	ProxyPass        / http://localhost:<%= node['stash']['tomcat']['port'] %>/ connectiontimeout=5 timeout=300
-	ProxyPassReverse / http://localhost:<%= node['stash']['tomcat']['port'] %>/
+	ProxyPass        / http://localhost:<%= port %>/ connectiontimeout=5 timeout=300
+	ProxyPassReverse / http://localhost:<%= port %>/
 
 	SSLEngine on
 	SSLCertificateFile <%= node['stash']['apache2']['ssl']['certificate_file'] %>
@@ -58,3 +54,5 @@
 	SSLCertificateChainFile <%= node['stash']['apache2']['ssl']['chain_file'] %>
 	<% end -%>
 </VirtualHost>
+
+<% end %>


### PR DESCRIPTION
When connecting to default fqdn connector from other CNAME (like stash.company.com),
it will cause some errors because the origin and the remote of the request are different.
This will create a connector for each CNAME, and use apache to proxy those requests to the right connector.

https://confluence.atlassian.com/kb/cross-site-request-forgery-csrf-protection-changes-in-atlassian-rest-779294918.html