### PR TITLE
Added checksums for versions 4.9.0 --> 4.14.5 in attributes/default.rb

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -166,6 +166,24 @@ default['stash']['checksum'] =
   when '4.8.1' then 'd77de9aa4f19114f118f2438b05dbd81191847d524b974feecd030937385b275'
   when '4.8.2' then '14962bdd1713f4f1ccd580158ae206249d5e4c3cf4596275b2c258edc18b20ac'
   when '4.8.3' then '8f5544e8b9e6cb444df6ce401425ec308c380e317618c40d8895f6ebb2aa6328'
+  when '4.9.0' then 'cc1d512b1c57994803eed9107a692277d32dfb9d6ebccb3e531eec17ee9d1c07'
+  when '4.9.1' then 'cc8833c9f69f9f33f89ca0a7ebd7efe2e604b5e37e1e77f3500c26217dfa6855'
+  when '4.10.0' then '65c0c672c6ea92c6fb2090d5f8a170b70a90cbb986af8304fc6bb4dce717451b'
+  when '4.10.1' then 'f625977f28d1fbbc7231fcea16bac8521fe3427e05063bfe4c1874be275d75cd'
+  when '4.10.2' then '003cddaa32597552da689731d155d6e1eebadd24b3768d512dfd15c848463ffc'
+  when '4.11.0' then '7b6238d52501e8946fbc536f3aba525d3948a5448b0184bf71e526be6c7d9e3d'
+  when '4.11.1' then '6595bf57b60b41a770c617171b478ae221de0aee1152a04d829751426b43f632'
+  when '4.11.2' then 'c804495c88a9ad3984c4d8c84260ca22bc4b5d6c4fa59fb510554fafcd2c868e'
+  when '4.12.0' then '50be63a7b94863c7d51fd269fb91143d256cf560476a1b6f46f0ed07a53a4914'
+  when '4.12.1' then '8ea5f0e145c4bcbec9879c8ac2d124329d000b9c4b74ce78408b0629a9ef1664'
+  when '4.13.0' then 'c98f343f51f81db6ebb7cf3e84737b07cdc7e919aeb039fa1fe1fe638b69971a'
+  when '4.13.1' then 'dec55ed960c92f6740c025bb6d28a4182c4362b1ea795b39803601af0401cd12'
+  when '4.14.0' then '6a5f020d0511df2da0550632fa863908233901f7436a8afd50d6e87d2bc04000'
+  when '4.14.1' then '8cfdfb39624686837a02ad50ff18de28d3de5bb3f8642821ab5049fd197faf67'
+  when '4.14.2' then '7d57355551db54d24f2dce768e602ecc3581cdf11431e0da2ec1a2c67fc46c12'
+  when '4.14.3' then '2d54b9424dbfe3a8a65dd8d908cfe670ace7cf2bfb597753c2048e1cf321f259'
+  when '4.14.4' then 'ba58a5be4064515613cbb3825f2dafd8ceaa9749fd1905a7b5a65f30247be337'
+  when '4.14.5' then 'f366fc5f4a1b1a41c3daa123d1f18fa166092dc479604694ef3e221b6d4e1f81'
   end
 
 # Data bag where credentials and other sensitive data could be stored (optional)
@@ -252,6 +270,7 @@ default['stash']['backup_client']['checksum'] =
   when '3.0.0' then '1a4dcea8fa5df919b9c92341b1a3b92aed5892022e0f94733540d1ebb88653df'
   when '3.1.0' then '7d586c65f6f0173c064e5d6508c380192c4a9ac3fc2314fbc3fce2e8f6b10daf'
   when '3.2.0' then 'e306e5d0b1f7bc36124ef2877df608b9c1fa2fb7e88d5252fc7dba680962b882'
+  when '3.3.2' then 'ee4439a80c3aa5fb4ab3bc7b44d633c1d063d4b988f9cdbc3b3a8ad886a84c80'
   end
 
 default['stash']['backup_diy']['install_path'] = "#{node['stash']['install_path']}/stash-diy-backup"


### PR DESCRIPTION
Created this so it can be added separately from the move to helper.rb if so desired.